### PR TITLE
Support for debug_stateRootWithUpdates method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 # [Unreleased]
 - Implement `receipt_by_hash` and `receipts_by_block` in `ReceiptProvider`
+- Introduce config for `AlloyRethProvider` and `AlloyRethStateProvider`
+  - This config allows to alter the return behavior of the provider for testing purposes
+- Implement optional `state_root_with_updates` using `debug_stateRootWithUpdates`
+- Implement `block_by_id` in `BlockReaderIdExt`
 
 # [1.4.3] - 2025-05-20
 - Update reth to 1.4.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7329eb72d95576dfb8813175bcf671198fb24266b0b3e520052a513e30c284df"
+checksum = "78090ff96d0d1b648dbcebc63b5305296b76ad4b5d4810f755d7d1224ced6247"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa190bfa5340aee544ac831114876fa73bc8da487095b49a5ea153a6a4656ea"
+checksum = "5fb7646210355c36b07886c91cac52e4727191e2b0ee1415cce8f953f6019dd2"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b81b2dfd278d58af8bfde8753fa4685407ba8fbad8bc88a2bb0e065eed48478"
+checksum = "85b14b506d7a4f739dd57ad5026d65eb64d842f4e971f71da5e9be5067ecbdc9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ed07e76fbc72790a911ea100cdfbe85b1f12a097c91b948042e854959d140e"
+checksum = "691a4825b3d08f031b49aae3c11cb35abf2af376fc11146bf8e5930a432dbf40"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa8b9e0aa91bfbd45a0c32490981ab7dfd523f8e075acdc8a3902eb24a7a5a3"
+checksum = "88c4a039f33025c4f4a88c121ce59f0b09a7ec159ac76c843dfb96a663cc48e8"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a3f7a59c276c6e410267e77a166f9297dbe74e4605f1abf625e29d85c53144"
+checksum = "1382ef9e0fa1ab3f5a3dbc0a0fa1193f3794d5c9d75fc22654bb6da1cf7a59cc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bcf49fe91b3d621440dcc5bb067afaeba5ca4b07f59e42fb7af42944146a8c0"
+checksum = "b73f8da3d6eb98abd8b1489953f56454df7bcdff9d3d0cafbe711fa6f51e7525"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d9b4293dfd4721781d33ee40de060376932d4a55d421cf6618ad66ff97cc52"
+checksum = "9b8acc64d23e484a0a27375b57caba34569729560a29aa366933f0ae07b7786f"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7d927aa39ca51545ae4c9cf4bdb2cbc1f6b46ab4b54afc3ed9255f93eedbce"
+checksum = "114c287eb4595f1e0844800efb0860dd7228fcf9bc77d52e303fb7a43eb766b2"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9b645fe4f4e6582cfbb4a8d20cedcf5aa23548e92eacbdacac6278b425e023"
+checksum = "46fb766c0bce9f62779a83048ca6d998c2ced4153d694027c66e537629f4fd61"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -3167,9 +3167,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb35d16e5420e43e400a235783e3d18b6ba564917139b668b48e9ac42cb3d35a"
+checksum = "b2423a125ef2daa0d15dacc361805a0b6f76d6acfc6e24a1ff6473582087fe75"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3202,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7534a0ec6b8409edc511acbe77abe7805aa63129b98e9a915bb4eb8555eaa6ff"
+checksum = "f82a315004b6720fbf756afdcfdc97ea7ddbcdccfec86ea7df7562bb0da29a3f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3221,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d58fbd3f89eaf3778a1da1e4da38c5074884a290bdbf5c66b1204a6df5b844"
+checksum = "47aea08d8ad3f533df0c5082d3e93428a4c57898b7ade1be928fa03918f22e71"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3827,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3915,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4002,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -4047,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4085,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "serde",
  "serde_json",
@@ -4144,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -4161,7 +4161,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "bindgen",
  "cc",
@@ -4170,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "metrics",
  "metrics-derive",
@@ -4179,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-chainspec"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4244,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-forks"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4274,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -4286,7 +4286,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4346,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4388,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4401,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4461,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -4493,7 +4493,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "clap",
  "eyre",
@@ -4508,7 +4508,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -4604,7 +4604,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
+source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3915,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4002,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -4047,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4085,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "serde",
  "serde_json",
@@ -4144,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -4161,7 +4161,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "bindgen",
  "cc",
@@ -4170,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "metrics",
  "metrics-derive",
@@ -4179,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-chainspec"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4244,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-forks"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4274,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -4286,7 +4286,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4346,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4388,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4401,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4461,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -4493,7 +4493,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "clap",
  "eyre",
@@ -4508,7 +4508,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -4604,7 +4604,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.4.3"
-source = "git+https://github.com/cakevm/reth?rev=7b4b9c0#7b4b9c0341d9763b5f8532866e17e8a20383ad45"
+source = "git+https://github.com/paradigmxyz/reth?rev=a4a9bca#a4a9bcaa74f5a583f874844ef4dddb95544a505b"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5848366a4f08dca1caca0a6151294a4799fe2e59ba25df100491d92e0b921b1c"
+checksum = "517e5acbd38b6d4c59da380e8bbadc6d365bf001903ce46cf5521c53c647e07b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -60,37 +60,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2179ba839ac532f50279f5da2a6c5047f791f03f6f808b4dfab11327b97902f"
+checksum = "7329eb72d95576dfb8813175bcf671198fb24266b0b3e520052a513e30c284df"
 dependencies = [
- "alloy-eips 0.14.0",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.14.0",
- "alloy-trie",
- "auto_impl",
- "c-kzg",
- "derive_more",
- "either",
- "k256",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_with",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-consensus"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9835a7b6216cb8118323581e58a18b1a5014fce55ce718635aaea7fa07bd700"
-dependencies = [
- "alloy-eips 1.0.5",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "alloy-trie",
  "auto_impl",
  "c-kzg",
@@ -107,29 +84,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec6f67bdc62aa277e0ec13c1b1fb396c8a62b65c8e9bd8c1d3583cc6d1a8dd3"
+checksum = "f31b286aeef04a32720c10defd21c3aa6c626154ac442b55f6d472caeb1c6741"
 dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-eips 0.14.0",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.14.0",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621e9f7d76ed95d21825286b180fcb89895d34244e41c89714da6d70398a16bc"
-dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -173,36 +136,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
+checksum = "4fa190bfa5340aee544ac831114876fa73bc8da487095b49a5ea153a6a4656ea"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.14.0",
- "auto_impl",
- "c-kzg",
- "derive_more",
- "either",
- "serde",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "alloy-eips"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fc566136b705991072f8f79762525e14f0ca39c38d45b034944770cb6c6b67"
-dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "auto_impl",
  "c-kzg",
  "derive_more",
@@ -215,12 +158,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0210f2d5854895b376f7fbbf78f3e33eb4f0e59abc503502cc0ed8d295a837"
+checksum = "394b09cf3a32773eedf11828987f9c72dfa74545040be0422e3f5f09a2a3fab9"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-sol-types",
@@ -234,22 +177,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c0124a3174f136171df8498e4700266774c9de1008a0b987766cf215d08f6"
+checksum = "2b81b2dfd278d58af8bfde8753fa4685407ba8fbad8bc88a2bb0e065eed48478"
 dependencies = [
- "alloy-eips 1.0.5",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "alloy-trie",
  "serde",
 ]
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40cc82a2283e3ce6317bc1f0134ea50d20e8c1965393045ee952fb28a65ddbd"
+checksum = "1d6b8067561eb8f884b215ace4c962313c5467e47bde6b457c8c51e268fb5d99"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -272,23 +215,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3994ab6ff6bdeb5aebe65381a8f6a47534789817570111555e8ac413e242ce06"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tracing",
-]
-
-[[package]]
-name = "alloy-json-rpc"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1590f44abdfe98686827a4e083b711ad17f843bf6ed8a50b78d3242f12a00ada"
+checksum = "89ab2dba5dca01ad4281b4d4726a18e2012a20e3950bfc2a90c5376840555366"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -300,46 +229,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be3aa020a6d3aa7601185b4c1a7d6f3a5228cb5424352db63064b29a455c891"
+checksum = "f0ed07e76fbc72790a911ea100cdfbe85b1f12a097c91b948042e854959d140e"
 dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-consensus-any 0.14.0",
- "alloy-eips 0.14.0",
- "alloy-json-rpc 0.14.0",
- "alloy-network-primitives 0.14.0",
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-any 0.14.0",
- "alloy-rpc-types-eth 0.14.0",
- "alloy-serde 0.14.0",
- "alloy-signer 0.14.0",
- "alloy-sol-types",
- "async-trait",
- "auto_impl",
- "derive_more",
- "futures-utils-wasm",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-network"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049a9022caa0c0a2dcd2bc2ea23fa098508f4a81d5dda774d753570a41e6acdb"
-dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-consensus-any 1.0.5",
- "alloy-eips 1.0.5",
- "alloy-json-rpc 1.0.5",
- "alloy-network-primitives 1.0.5",
- "alloy-primitives",
- "alloy-rpc-types-any 1.0.5",
- "alloy-rpc-types-eth 1.0.5",
- "alloy-serde 1.0.5",
- "alloy-signer 1.0.5",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -352,41 +255,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498f2ee2eef38a6db0fc810c7bf7daebdf5f2fa8d04adb8bd53e54e91ddbdea3"
+checksum = "f05aa52713c376f797b3c7077708585f22a5c3053a7b1b2b355ea98edeb2052d"
 dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-eips 0.14.0",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 0.14.0",
- "serde",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c6fb35478d017304f4e9188daaebe5f206d44c77dbba749158427a50fdafc"
-dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
- "alloy-primitives",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da198d78f58c199408003c7b9dc999d61e7033bba68f2e3f135e510a3bd0960"
+checksum = "4aa8b9e0aa91bfbd45a0c32490981ab7dfd523f8e075acdc8a3902eb24a7a5a3"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
- "alloy-network 1.0.5",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 1.0.5",
+ "alloy-signer",
  "alloy-signer-local",
  "k256",
  "rand 0.8.5",
@@ -399,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-hardforks"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79617217008626a24fb52b02d532bf4554ac9b184a2d22bd6c5df628c151601"
+checksum = "08043c9284e597f9b5cf741cc6d906fdb26c195a01d88423c84c00ffda835713"
 dependencies = [
  "alloy-hardforks",
  "auto_impl",
@@ -436,60 +326,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6ba76d476f475668925f858cc4db51781f12abdaa4e0274eb57a09f574e869"
+checksum = "05a3f7a59c276c6e410267e77a166f9297dbe74e4605f1abf625e29d85c53144"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.14.0",
- "alloy-eips 0.14.0",
- "alloy-json-rpc 0.14.0",
- "alloy-network 0.14.0",
- "alloy-network-primitives 0.14.0",
- "alloy-primitives",
- "alloy-rpc-client 0.14.0",
- "alloy-rpc-types-eth 0.14.0",
- "alloy-signer 0.14.0",
- "alloy-sol-types",
- "alloy-transport 0.14.0",
- "async-stream",
- "async-trait",
- "auto_impl",
- "dashmap",
- "either",
- "futures",
- "futures-utils-wasm",
- "lru",
- "parking_lot",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-provider"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "959aedfc417737e2a59961c95e92c59726386748d85ef516a0d0687b440d3184"
-dependencies = [
- "alloy-chains",
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
- "alloy-json-rpc 1.0.5",
- "alloy-network 1.0.5",
- "alloy-network-primitives 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-rpc-client 1.0.5",
- "alloy-rpc-types-eth 1.0.5",
- "alloy-signer 1.0.5",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
  "alloy-sol-types",
- "alloy-transport 1.0.5",
- "alloy-transport-http 1.0.5",
+ "alloy-transport",
+ "alloy-transport-http",
  "alloy-transport-ws",
  "async-stream",
  "async-trait",
@@ -513,13 +367,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf694cd1494284e73e23b62568bb5df6777f99eaec6c0a4705ac5a5c61707208"
+checksum = "fc3cbf02fdedbec7aadc7a77080b6b143752fa792c7fd49b86fd854257688bd4"
 dependencies = [
- "alloy-json-rpc 1.0.5",
+ "alloy-json-rpc",
  "alloy-primitives",
- "alloy-transport 1.0.5",
+ "alloy-transport",
  "bimap",
  "futures",
  "parking_lot",
@@ -534,16 +388,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-reth-provider"
-version = "1.4.3"
+version = "1.4.3-v2"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
- "alloy-network 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network",
  "alloy-node-bindings",
  "alloy-primitives",
- "alloy-provider 1.0.5",
- "alloy-rpc-types-eth 1.0.5",
- "alloy-transport 1.0.5",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-transport",
  "eyre",
  "futures-util",
  "op-alloy-network",
@@ -599,38 +453,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6a6985b48a536b47aa0aece56e6a0f49240ce5d33a7f0c94f1b312eda79aa1"
+checksum = "d5f185483536cbcbf55971077140e03548dad4f3a4ddb35044bcdc01b8f02ce1"
 dependencies = [
- "alloy-json-rpc 0.14.0",
- "alloy-primitives",
- "alloy-transport 0.14.0",
- "alloy-transport-http 0.14.0",
- "async-stream",
- "futures",
- "pin-project",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
- "tracing-futures",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-rpc-client"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20436220214938c4fe223244f00fbd618dda80572b8ffe7839d382a6c54f1c"
-dependencies = [
- "alloy-json-rpc 1.0.5",
+ "alloy-json-rpc",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-transport 1.0.5",
- "alloy-transport-http 1.0.5",
+ "alloy-transport",
+ "alloy-transport-http",
  "alloy-transport-ws",
  "async-stream",
  "futures",
@@ -649,37 +480,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a40595b927dfb07218459037837dbc8de8500a26024bb6ff0548dd2ccc13e0"
+checksum = "67971a228100ac65bd86e90439028853435f21796330ef08f00a70a918a84126"
 dependencies = [
- "alloy-consensus-any 0.14.0",
- "alloy-rpc-types-eth 0.14.0",
- "alloy-serde 0.14.0",
-]
-
-[[package]]
-name = "alloy-rpc-types-any"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380a951cddc3a46d4b8755f2c5ebde9ae0da373736b64222833c5f3a0773a1cc"
-dependencies = [
- "alloy-consensus-any 1.0.5",
- "alloy-rpc-types-eth 1.0.5",
- "alloy-serde 1.0.5",
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bc248ac9ba1e521096166020ddda953ba9420fc5a6466ad0811264fe88b677"
+checksum = "2bcf49fe91b3d621440dcc5bb067afaeba5ca4b07f59e42fb7af42944146a8c0"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -690,37 +510,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a9f64e0f69cfb6029e2a044519a1bdd44ce9fc334d5315a7b9837f7a6748e5"
+checksum = "89d9b4293dfd4721781d33ee40de060376932d4a55d421cf6618ad66ff97cc52"
 dependencies = [
- "alloy-consensus 0.14.0",
- "alloy-consensus-any 0.14.0",
- "alloy-eips 0.14.0",
- "alloy-network-primitives 0.14.0",
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.14.0",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2c0dad584b1556528ca651f4ae17bef82734b499ccfcee69f117fea66c3293"
-dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-consensus-any 1.0.5",
- "alloy-eips 1.0.5",
- "alloy-network-primitives 1.0.5",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.0.5",
+ "alloy-serde",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -730,20 +530,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c34ffc38f543bfdceed8c1fa5253fa5131455bb3654976be4cc3a4ae6d61f4"
+checksum = "3b7d927aa39ca51545ae4c9cf4bdb2cbc1f6b46ab4b54afc3ed9255f93eedbce"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -752,24 +541,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c580da7f00f3999e44e327223044d6732358627f93043e22d92c583f6583556"
-dependencies = [
- "alloy-primitives",
- "async-trait",
- "auto_impl",
- "either",
- "elliptic-curve",
- "k256",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-signer"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59245704a5dbd20b93913f4a20aa41b45c4c134f82e119bb54de4b627e003955"
+checksum = "c63771b50008d2b079187e9e74a08235ab16ecaf4609b4eb895e2890a3bcd465"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -782,14 +556,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae78644ab0945e95efa2dc0cfac8f53aa1226fe85c294a0d8ad82c5cc9f09a2"
+checksum = "db906294ee7876bd332cd760f460d30de183554434e07fc19d7d54e16a7aeaf0"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-network 1.0.5",
+ "alloy-consensus",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 1.0.5",
+ "alloy-signer",
  "async-trait",
  "k256",
  "rand 0.8.5",
@@ -868,33 +642,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1f1a55f9ff9a48aa0b4a8c616803754620010fbb266edae2f4548f4304373b"
+checksum = "ca9b645fe4f4e6582cfbb4a8d20cedcf5aa23548e92eacbdacac6278b425e023"
 dependencies = [
- "alloy-json-rpc 0.14.0",
- "base64",
- "derive_more",
- "futures",
- "futures-utils-wasm",
- "parking_lot",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tokio",
- "tower",
- "tracing",
- "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-transport"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56afd0561a291e84de9d5616fa3def4c4925a09117ea3b08d4d5d207c4f7083"
-dependencies = [
- "alloy-json-rpc 1.0.5",
+ "alloy-json-rpc",
  "alloy-primitives",
  "base64",
  "derive_more",
@@ -913,22 +665,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171b3d8824b6697d6c8325373ec410d230b6c59ce552edfbfabe4e7b8a26aac3"
+checksum = "ee18869ecabe658ff6316e7db7c25d958c7d10f0a1723c2f7447d4f402920b66"
 dependencies = [
- "alloy-transport 0.14.0",
- "url",
-]
-
-[[package]]
-name = "alloy-transport-http"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90770711e649bb3df0a8a666ae7b80d1d77eff5462eaf6bb4d3eaf134f6e636e"
-dependencies = [
- "alloy-json-rpc 1.0.5",
- "alloy-transport 1.0.5",
+ "alloy-json-rpc",
+ "alloy-transport",
  "reqwest",
  "serde_json",
  "tower",
@@ -938,12 +680,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90569cc2e13f5cdf53f42d5b3347cf4a89fccbcf9978cf08b165b4a1c6447672"
+checksum = "f7c838e7562d16110fba3590a20c7765281c1a302cf567e1806d0c3ce1352b58"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport 1.0.5",
+ "alloy-transport",
  "futures",
  "http",
  "rustls",
@@ -1026,12 +768,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -3172,14 +2914,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3418,18 +3160,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "op-alloy-consensus"
-version = "0.16.0"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f318b09e24148f07392c5e011bae047a0043851f9041145df5f3b01e4fedd1e"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb35d16e5420e43e400a235783e3d18b6ba564917139b668b48e9ac42cb3d35a"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
- "alloy-network 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.5",
- "alloy-serde 1.0.5",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "derive_more",
  "serde",
  "serde_with",
@@ -3438,31 +3186,32 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-network"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a567640236a672a1a0007959c437dbe846dd3e8e9b1d5656dba9c8b4879f67a"
+checksum = "a1cdaafbdb872e70525bdfe91f9d11997d46ed30950a922096a41a3b1037cdb3"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-network 1.0.5",
+ "alloy-consensus",
+ "alloy-network",
  "alloy-primitives",
- "alloy-rpc-types-eth 1.0.5",
- "alloy-signer 1.0.5",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15ede8322c10c21249de4fced204e2af4978972e715afee34b6fe684d73880cf"
+checksum = "7534a0ec6b8409edc511acbe77abe7805aa63129b98e9a915bb4eb8555eaa6ff"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
- "alloy-network-primitives 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-eth 1.0.5",
- "alloy-serde 1.0.5",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "derive_more",
  "op-alloy-consensus",
  "serde",
@@ -3472,12 +3221,12 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f6cb2e937e88faa8f3d38d38377398d17e44cecd5b019e6d7e1fbde0f5af2a"
+checksum = "32d58fbd3f89eaf3778a1da1e4da38c5074884a290bdbf5c66b1204a6df5b844"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -3490,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d9ddee86c9927dd88cd3037008f98c04016b013cd7c2822015b134e8d9b465"
+checksum = "47296d449fbe2d5cc74ab6e1213dee88cae3e2fd238343bec605c3c687bbcfab"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -4078,10 +3827,10 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "derive_more",
  "metrics",
@@ -4104,11 +3853,11 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -4124,10 +3873,10 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -4142,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -4153,9 +3902,9 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
+ "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -4166,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4190,9 +3939,9 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
+ "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
  "bytes",
@@ -4215,9 +3964,9 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-eips 1.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
@@ -4229,9 +3978,9 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
+ "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -4253,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -4264,11 +4013,11 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -4285,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -4298,10 +4047,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "modular-bitfield",
@@ -4315,10 +4064,10 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -4336,10 +4085,10 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "reth-chainspec",
@@ -4354,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4367,10 +4116,10 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "derive_more",
@@ -4385,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "serde",
  "serde_json",
@@ -4395,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -4412,7 +4161,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "bindgen",
  "cc",
@@ -4421,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "metrics",
  "metrics-derive",
@@ -4430,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4443,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4460,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -4473,11 +4222,11 @@ dependencies = [
 [[package]]
 name = "reth-optimism-chainspec"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-primitives",
@@ -4495,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-forks"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -4506,10 +4255,10 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
@@ -4525,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -4537,9 +4286,9 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-eips 1.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -4556,9 +4305,9 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
+ "alloy-consensus",
  "once_cell",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -4569,10 +4318,10 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -4597,10 +4346,10 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "dashmap",
@@ -4639,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4652,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -4664,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -4677,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4688,10 +4437,10 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -4712,9 +4461,9 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-eips 1.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -4728,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -4744,7 +4493,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "clap",
  "eyre",
@@ -4759,10 +4508,10 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -4795,10 +4544,10 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
- "alloy-eips 1.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -4819,13 +4568,13 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
- "alloy-consensus 1.0.5",
+ "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.5",
- "alloy-serde 1.0.5",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "alloy-trie",
  "bytes",
  "derive_more",
@@ -4842,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -4855,10 +4604,11 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-trie",
  "auto_impl",
  "reth-execution-errors",
  "reth-primitives-traits",
@@ -4870,16 +4620,16 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.4.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.3#fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=29e4e20#29e4e20f2ae8a1daee15ca50e6fa16c644457a11"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "23.1.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1eb83c8652836bc0422f9a144522179134d8befcc7ab595c1ada60dac39e51"
+checksum = "6d3ae9d1b08303eb5150dcf820a29e14235cf3f24f6c09024458a4dcbffe6695"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -4896,9 +4646,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a052afe63f2211d0b8be342ba4eff04b143be4bc77c2a96067ab6b90a90865d7"
+checksum = "d91f9b90b3bab18942252de2d970ee8559794c49ca7452b2cc1774456040f8fb"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -4909,9 +4659,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd6faa992a1a10b84723326d6117203764c040d3519fd1ba34950d049389eb7"
+checksum = "b181214eb2bbb76ee9d6195acba19857d991d2cdb9a65b7cb6939c30250a3966"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -4925,9 +4675,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2b42cac141cd388c38db420d3d18e7b23013c5747d5ed648d2d9a225263d51"
+checksum = "1b844f48a411e62c7dde0f757bf5cce49c85b86d6fc1d3b2722c07f2bec4c3ce"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -4941,13 +4691,13 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16e1a58d5614bef333402ae8682d0ea7ba4f4b0563b3a58a6c0ad9d392db4f6"
+checksum = "ad3fbe34f6bb00a9c3155723b3718b9cb9f17066ba38f9eb101b678cd3626775"
 dependencies = [
- "alloy-eips 0.14.0",
- "alloy-provider 0.14.0",
- "alloy-transport 0.14.0",
+ "alloy-eips",
+ "alloy-provider",
+ "alloy-transport",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -4958,9 +4708,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6839eb2e1667d3acd9cba59f77299fae8802c229fae50bc6f0435ed4c4ef398e"
+checksum = "7b8acd36784a6d95d5b9e1b7be3ce014f1e759abb59df1fa08396b30f71adc2a"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -4971,9 +4721,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511e50a8c7f14e97681ec96266ee53bf8316c0dea1d4a6633ff6f37c5c0fe9d0"
+checksum = "08a9204e3ac1a8edb850cc441a6a1d0f2251c0089e5fffdaba11566429e6c64e"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -4989,9 +4739,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f6c88fcf481f8e315bfd87377aa0ae83e1159dd381430122cbf431474ce39c"
+checksum = "ae4881eeae6ff35417c8569bc7cc03b6c0969869ee2c9b3945a39b4f9fa58bc5"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -5006,9 +4756,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "19.1.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b7d75106333808bc97df3cd6a1864ced4ffec9be28fd3e459733813f3c300e"
+checksum = "b5ee65e57375c6639b0f50555e92a4f1b2434349dd32f52e2176f5c711171697"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -5018,9 +4768,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "20.1.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06769068a34fd237c74193118530af3912e1b16922137a96fc302f29c119966"
+checksum = "0f9311e735123d8d53a02af2aa81877bba185be7c141be7f931bb3d2f3af449c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -5042,9 +4792,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "19.0.0"
+version = "19.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d8369df999a4d5d7e53fd866c43a19d38213a00e1c86f72b782bbe7b19cb30"
+checksum = "18ea2ea0134568ee1e14281ce52f60e2710d42be316888d464c53e37ff184fd8"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -5053,9 +4803,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac26c71bf0fe5a9cd9fe6adaa13487afedbf8c2ee6e228132eae074cb3c2b58"
+checksum = "0040c61c30319254b34507383ba33d85f92949933adf6525a2cede05d165e1fa"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -5127,9 +4877,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
+checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -5258,9 +5008,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"
@@ -5875,9 +5625,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.4.3-v2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.85"
-homepage = "https://github.com/cakevm/alloy-reth-provider"
-repository = "https://github.com/cakevm/alloy-reth-provider"
+homepage = "https://github.com/paradigmxyz/alloy-reth-provider"
+repository = "https://github.com/paradigmxyz/alloy-reth-provider"
 exclude = [".github/"]
 description = "Implement reth StateProviderFactory traits for remote RPC usage"
 
@@ -37,23 +37,27 @@ op-alloy-network = { version = "0.17.1", default-features = false, optional = tr
 op-alloy-rpc-types = { version = "0.17.1", default-features = false, optional = true }
 
 # reth
-reth-chainspec = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
-reth-db-models = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
-reth-errors = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
-reth-evm = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
-reth-primitives = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false, features = ["serde-bincode-compat"] }
-reth-primitives-traits = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
-reth-provider = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
-reth-revm = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
-reth-trie = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false }
+reth-db-models = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false, features = [
+  "serde-bincode-compat",
+] }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false }
 
 # ethereum
-reth-ethereum-primitives = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false, features = ["reth-codec"] }
-reth-evm-ethereum = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false, features = [
+  "reth-codec",
+] }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false }
 
 # optimism
-reth-optimism-chainspec = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false, optional = true }
-reth-optimism-primitives = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false, features = [
+reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false, optional = true }
+reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca", default-features = false, features = [
   "alloy-compat",
   "reth-codec",
   "serde",
@@ -69,9 +73,9 @@ alloy-node-bindings = "1.0.8"
 alloy-provider = { version = "1.0.8", default-features = false, features = ["alloy-transport-ws", "reqwest", "reqwest-default-tls", "ws"] }
 eyre = "0.6.12"
 futures-util = "0.3.31"
-reth-revm = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0" }
-reth-tasks = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0" }
-reth-transaction-pool = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a4a9bca" }
 ruint = "1.15.0"
 test-with = { version = "0.14.10", default-features = false }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-reth-provider"
-version = "1.4.3"
+version = "1.4.3-v2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.85"
@@ -16,48 +16,48 @@ tokio = { version = "1.43.0", default-features = false, features = ["rt-multi-th
 tracing = "0.1.41"
 
 # revm
-revm = { version = "23.1.0", default-features = false, features = ["alloydb"] }
-revm-context = { version = "4.0.0", default-features = false }
+revm = { version = "24.0.0", default-features = false, features = ["alloydb"] }
+revm-context = { version = "5.0.0", default-features = false }
 revm-database = { version = "4.0.0", default-features = false }
 revm-state = { version = "4.0.0", default-features = false }
 
 # alloy
-alloy-consensus = { version = "1.0.5", default-features = false }
-alloy-eips = { version = "1.0.5", default-features = false }
-alloy-network = { version = "1.0.5", default-features = false }
+alloy-consensus = { version = "1.0.7", default-features = false }
+alloy-eips = { version = "1.0.7", default-features = false }
+alloy-network = { version = "1.0.7", default-features = false }
 alloy-primitives = { version = "1.1.2", default-features = false }
-alloy-provider = { version = "1.0.5", default-features = false }
-alloy-transport = { version = "1.0.5", default-features = false }
+alloy-provider = { version = "1.0.7", default-features = false }
+alloy-transport = { version = "1.0.7", default-features = false }
 
 # eth-alloy
-alloy-rpc-types-eth = { version = "1.0.5", default-features = false }
+alloy-rpc-types-eth = { version = "1.0.7", default-features = false }
 
 # op-alloy
-op-alloy-network = { version = "0.16.0", default-features = false, optional = true }
-op-alloy-rpc-types = { version = "0.16.0", default-features = false, optional = true }
+op-alloy-network = { version = "0.17.1", default-features = false, optional = true }
+op-alloy-rpc-types = { version = "0.17.1", default-features = false, optional = true }
 
 # reth
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false }
-reth-db-models = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false, features = [
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
+reth-db-models = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false, features = [
   "serde-bincode-compat",
 ] }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
 
 # ethereum
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false, features = [
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false, features = [
   "reth-codec",
 ] }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
 
 # optimism
-reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false, optional = true }
-reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3", default-features = false, features = [
+reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false, optional = true }
+reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false, features = [
   "alloy-compat",
   "reth-codec",
   "serde",
@@ -68,14 +68,14 @@ reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", tag = 
 optimism = ["op-alloy-network", "op-alloy-rpc-types", "reth-optimism-chainspec", "reth-optimism-primitives"]
 
 [dev-dependencies]
-alloy-eips = { version = "1.0.5", default-features = false, features = ["kzg"] }
-alloy-node-bindings = "1.0.5"
-alloy-provider = { version = "1.0.5", default-features = false, features = ["alloy-transport-ws", "reqwest", "reqwest-default-tls", "ws"] }
+alloy-eips = { version = "1.0.7", default-features = false, features = ["kzg"] }
+alloy-node-bindings = "1.0.7"
+alloy-provider = { version = "1.0.7", default-features = false, features = ["alloy-transport-ws", "reqwest", "reqwest-default-tls", "ws"] }
 eyre = "0.6.12"
 futures-util = "0.3.31"
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.3" }
-ruint = "1.14.0"
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20" }
+ruint = "1.15.0"
 test-with = { version = "0.14.10", default-features = false }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,42 +22,38 @@ revm-database = { version = "4.0.0", default-features = false }
 revm-state = { version = "4.0.0", default-features = false }
 
 # alloy
-alloy-consensus = { version = "1.0.7", default-features = false }
-alloy-eips = { version = "1.0.7", default-features = false }
-alloy-network = { version = "1.0.7", default-features = false }
+alloy-consensus = { version = "1.0.8", default-features = false }
+alloy-eips = { version = "1.0.8", default-features = false }
+alloy-network = { version = "1.0.8", default-features = false }
 alloy-primitives = { version = "1.1.2", default-features = false }
-alloy-provider = { version = "1.0.7", default-features = false }
-alloy-transport = { version = "1.0.7", default-features = false }
+alloy-provider = { version = "1.0.8", default-features = false }
+alloy-transport = { version = "1.0.8", default-features = false }
 
 # eth-alloy
-alloy-rpc-types-eth = { version = "1.0.7", default-features = false }
+alloy-rpc-types-eth = { version = "1.0.8", default-features = false }
 
 # op-alloy
 op-alloy-network = { version = "0.17.1", default-features = false, optional = true }
 op-alloy-rpc-types = { version = "0.17.1", default-features = false, optional = true }
 
 # reth
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
-reth-db-models = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false, features = [
-  "serde-bincode-compat",
-] }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
+reth-chainspec = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
+reth-db-models = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
+reth-errors = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
+reth-evm = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
+reth-primitives = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false, features = ["serde-bincode-compat"] }
+reth-primitives-traits = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
+reth-provider = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
+reth-revm = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
+reth-trie = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
 
 # ethereum
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false, features = [
-  "reth-codec",
-] }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false, features = ["reth-codec"] }
+reth-evm-ethereum = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false }
 
 # optimism
-reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false, optional = true }
-reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20", default-features = false, features = [
+reth-optimism-chainspec = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false, optional = true }
+reth-optimism-primitives = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0", default-features = false, features = [
   "alloy-compat",
   "reth-codec",
   "serde",
@@ -68,14 +64,14 @@ reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", rev = 
 optimism = ["op-alloy-network", "op-alloy-rpc-types", "reth-optimism-chainspec", "reth-optimism-primitives"]
 
 [dev-dependencies]
-alloy-eips = { version = "1.0.7", default-features = false, features = ["kzg"] }
-alloy-node-bindings = "1.0.7"
-alloy-provider = { version = "1.0.7", default-features = false, features = ["alloy-transport-ws", "reqwest", "reqwest-default-tls", "ws"] }
+alloy-eips = { version = "1.0.8", default-features = false, features = ["kzg"] }
+alloy-node-bindings = "1.0.8"
+alloy-provider = { version = "1.0.8", default-features = false, features = ["alloy-transport-ws", "reqwest", "reqwest-default-tls", "ws"] }
 eyre = "0.6.12"
 futures-util = "0.3.31"
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "29e4e20" }
+reth-revm = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0" }
+reth-tasks = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0" }
+reth-transaction-pool = { git = "https://github.com/cakevm/reth", rev = "7b4b9c0" }
 ruint = "1.15.0"
 test-with = { version = "0.14.10", default-features = false }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/deny.toml
+++ b/deny.toml
@@ -32,4 +32,4 @@ ignore = [
 multiple-versions = "allow"
 
 [sources]
-allow-git = ["https://github.com/paradigmxyz/reth"]
+allow-git = ["https://github.com/cakevm/reth"]

--- a/deny.toml
+++ b/deny.toml
@@ -32,4 +32,4 @@ ignore = [
 multiple-versions = "allow"
 
 [sources]
-allow-git = ["https://github.com/cakevm/reth"]
+allow-git = ["https://github.com/paradigmxyz/reth"]

--- a/examples/mempool.rs
+++ b/examples/mempool.rs
@@ -1,6 +1,5 @@
 #[cfg(not(feature = "optimism"))]
 mod eth_imports {
-    pub use alloy_consensus::transaction::PooledTransaction;
     pub use alloy_eips::eip4844::env_settings::EnvKzgSettings;
     pub use alloy_eips::{Decodable2718, Encodable2718};
     pub use alloy_provider::{Provider, ProviderBuilder, WsConnect};
@@ -9,6 +8,7 @@ mod eth_imports {
     pub use eyre::eyre;
     pub use futures_util::stream::StreamExt;
     pub use reth_ethereum_primitives::EthPrimitives;
+    pub use reth_ethereum_primitives::PooledTransactionVariant;
     pub use reth_primitives_traits::SignedTransaction;
     pub use reth_provider::StateReader;
     pub use reth_provider::{BlockNumReader, BlockReader, CanonStateNotification, CanonStateSubscriptions, Chain};
@@ -105,7 +105,7 @@ async fn main() -> eyre::Result<()> {
                     // The easiest way to get `alloy_rpc_types_eth` to the reth type is by encoding and decoding
                     // But 4844 transactions are not working yet
                     let tx_raw = tx.inner.encoded_2718();
-                    let tx = match PooledTransaction::decode_2718(&mut tx_raw.as_ref()) {
+                    let tx = match PooledTransactionVariant::decode_2718(&mut tx_raw.as_ref()) {
                         Ok(tx) => tx,
                         Err(e) => {
                             tracing::error!("Error decoding tx: {:?}", e);

--- a/examples/mempool.rs
+++ b/examples/mempool.rs
@@ -5,6 +5,7 @@ mod eth_imports {
     pub use alloy_provider::{Provider, ProviderBuilder, WsConnect};
     pub use alloy_reth_provider::utils::rpc_block_to_recovered_block;
     pub use alloy_reth_provider::AlloyRethProvider;
+    pub use alloy_reth_provider::{AlloyRethProviderConfig, GetStateExecutionOutcome};
     pub use eyre::eyre;
     pub use futures_util::stream::StreamExt;
     pub use reth_ethereum_primitives::EthPrimitives;
@@ -44,7 +45,8 @@ async fn main() -> eyre::Result<()> {
 
     let ws = WsConnect::new("wss://eth.llamarpc.com");
     let ws_provider = ProviderBuilder::new().connect_ws(ws).await?;
-    let reth_provider = AlloyRethProvider::new(ws_provider.clone(), EthPrimitives::default());
+    let config = AlloyRethProviderConfig { get_state_execution_outcome: GetStateExecutionOutcome::Full, ..Default::default() };
+    let reth_provider = AlloyRethProvider::new_with_config(ws_provider.clone(), EthPrimitives::default(), config);
 
     let canon_state_notification_sender = reth_provider.canon_state_notification_sender.clone();
     let block_subscription = ws_provider.subscribe_full_blocks().full();

--- a/examples/state_root.rs
+++ b/examples/state_root.rs
@@ -1,0 +1,50 @@
+#[cfg(not(feature = "optimism"))]
+mod eth_imports {
+    pub use alloy_eips::BlockId;
+    pub use alloy_primitives::keccak256;
+    pub use alloy_primitives::map::B256Map;
+    pub use alloy_primitives::{address, U256};
+    pub use alloy_provider::ProviderBuilder;
+    pub use alloy_reth_provider::AlloyRethProvider;
+    pub use reth_ethereum_primitives::EthPrimitives;
+    pub use reth_provider::StateProviderFactory;
+    pub use reth_provider::{AccountReader, StateRootProvider};
+    pub use reth_trie::HashedPostState;
+    pub use std::env;
+}
+
+#[cfg(not(feature = "optimism"))]
+use eth_imports::*;
+
+#[cfg(feature = "optimism")]
+fn main() {
+    println!("Optimism not implemented");
+}
+
+#[cfg(not(feature = "optimism"))]
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    let node_url = env::var("MAINNET_HTTP")?;
+    let provider = ProviderBuilder::default().connect_http(node_url.parse()?);
+    let db_provider = AlloyRethProvider::new(provider, EthPrimitives::default());
+
+    // Get state provider for latest block
+    let latest_state = db_provider.state_by_block_id(BlockId::latest())?;
+
+    // Some random state change
+    let address = address!("0x4838b106fce9647bdf1e7877bf73ce8b0bad5f97");
+    let mut account = latest_state.basic_account(&address)?.unwrap();
+    account.balance = U256::ONE;
+    let hashed_address = keccak256(address);
+    let accounts = B256Map::from_iter([(hashed_address, Some(account))]);
+
+    let hashed_post_state = HashedPostState { accounts, storages: Default::default() };
+
+    // Get the state root and trie for our hashed post state
+    let (root, trie) = latest_state.state_root_with_updates(hashed_post_state)?;
+    println!("state root: {}", root);
+    println!("account_nodes length: {}", trie.account_nodes.len());
+    println!("removed_nodes length: {}", trie.removed_nodes.len());
+    println!("storage_tries length: {}", trie.storage_tries.len());
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub use provider::alloy_reth_provider::AlloyRethProvider;
+pub use provider::alloy_reth_provider::{AlloyRethProvider, AlloyRethProviderConfig, GetStateExecutionOutcome};
 pub use state_provider::alloy_reth_state_provider::{AlloyRethStateProvider, AlloyRethStateProviderConfig};
 
 pub mod alloy_db;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub use provider::alloy_reth_provider::AlloyRethProvider;
-pub use state_provider::alloy_reth_state_provider::AlloyRethStateProvider;
+pub use state_provider::alloy_reth_state_provider::{AlloyRethStateProvider, AlloyRethStateProviderConfig};
 
 pub mod alloy_db;
 pub mod primitives;

--- a/src/provider/alloy_reth_provider.rs
+++ b/src/provider/alloy_reth_provider.rs
@@ -1,4 +1,5 @@
 use crate::primitives::AlloyRethNodePrimitives;
+use crate::state_provider::alloy_reth_state_provider::AlloyRethStateProviderConfig;
 use crate::AlloyNetwork;
 use alloy_provider::Provider;
 use reth_ethereum_primitives::EthPrimitives;
@@ -10,6 +11,7 @@ use tokio::sync::broadcast;
 pub struct AlloyRethProvider<P: Send + Sync + Debug + Clone + 'static, NP: AlloyRethNodePrimitives> {
     pub(crate) provider: P,
     pub canon_state_notification_sender: CanonStateNotificationSender<EthPrimitives>,
+    pub(crate) state_provider_config: AlloyRethStateProviderConfig,
     _np: NP,
 }
 
@@ -20,7 +22,12 @@ where
 {
     pub fn new(provider: P, _np: NP) -> Self {
         let (canon_state_notification_sender, _) = broadcast::channel(256);
-        Self { provider, canon_state_notification_sender, _np }
+        Self { provider, canon_state_notification_sender, _np, state_provider_config: AlloyRethStateProviderConfig::default() }
+    }
+
+    pub fn new_with_config(provider: P, _np: NP, state_provider_config: AlloyRethStateProviderConfig) -> Self {
+        let (canon_state_notification_sender, _) = broadcast::channel(256);
+        Self { provider, canon_state_notification_sender, _np, state_provider_config }
     }
 }
 

--- a/src/provider/alloy_reth_provider.rs
+++ b/src/provider/alloy_reth_provider.rs
@@ -7,11 +7,29 @@ use reth_provider::CanonStateNotificationSender;
 use std::fmt::Debug;
 use tokio::sync::broadcast;
 
+#[derive(Debug, Clone, Default)]
+pub enum GetStateExecutionOutcome {
+    /// An empty `ExecutionOutcome` will be returned.
+    #[default]
+    Empty,
+    /// The block will locally execute and the `ExecutionOutcome` is fully populated.
+    /// This will be the slowest option, as it requires executing the block.
+    Full,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AlloyRethProviderConfig {
+    /// State provider configuration for the `AlloyRethStateProvider`.
+    pub state_provider_config: AlloyRethStateProviderConfig,
+    /// How the `ExecutionOutcome` for `get_state` should be returned.
+    pub get_state_execution_outcome: GetStateExecutionOutcome,
+}
+
 #[derive(Clone, Debug)]
 pub struct AlloyRethProvider<P: Send + Sync + Debug + Clone + 'static, NP: AlloyRethNodePrimitives> {
     pub(crate) provider: P,
     pub canon_state_notification_sender: CanonStateNotificationSender<EthPrimitives>,
-    pub(crate) state_provider_config: AlloyRethStateProviderConfig,
+    pub(crate) reth_provider_config: AlloyRethProviderConfig,
     _np: NP,
 }
 
@@ -22,12 +40,12 @@ where
 {
     pub fn new(provider: P, _np: NP) -> Self {
         let (canon_state_notification_sender, _) = broadcast::channel(256);
-        Self { provider, canon_state_notification_sender, _np, state_provider_config: AlloyRethStateProviderConfig::default() }
+        Self { provider, canon_state_notification_sender, _np, reth_provider_config: AlloyRethProviderConfig::default() }
     }
 
-    pub fn new_with_config(provider: P, _np: NP, state_provider_config: AlloyRethStateProviderConfig) -> Self {
+    pub fn new_with_config(provider: P, _np: NP, reth_provider_config: AlloyRethProviderConfig) -> Self {
         let (canon_state_notification_sender, _) = broadcast::channel(256);
-        Self { provider, canon_state_notification_sender, _np, state_provider_config }
+        Self { provider, canon_state_notification_sender, _np, reth_provider_config }
     }
 }
 

--- a/src/provider/storage_api/block.rs
+++ b/src/provider/storage_api/block.rs
@@ -145,8 +145,11 @@ where
     P: Provider<AlloyNetwork> + Send + Sync + Debug + Clone + 'static,
     NP: AlloyRethNodePrimitives,
 {
-    fn block_by_id(&self, _id: BlockId) -> ProviderResult<Option<Self::Block>> {
-        todo!()
+    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Self::Block>> {
+        match id {
+            BlockId::Number(num) => self.block_by_number_or_tag(num),
+            BlockId::Hash(hash) => self.block_by_hash(hash.block_hash),
+        }
     }
 
     fn sealed_header_by_id(&self, _id: BlockId) -> ProviderResult<Option<SealedHeader<Self::Header>>> {

--- a/src/provider/storage_api/receipts.rs
+++ b/src/provider/storage_api/receipts.rs
@@ -2,14 +2,14 @@ use crate::primitives::AlloyRethNodePrimitives;
 use crate::utils::rpc_receipt_to_receipt;
 use crate::{AlloyNetwork, AlloyRethProvider};
 use alloy_eips::BlockHashOrNumber;
-use alloy_primitives::{TxHash, TxNumber};
+use alloy_primitives::{BlockNumber, TxHash, TxNumber};
 use alloy_provider::Provider;
 use reth_errors::{ProviderError, ProviderResult};
 use reth_primitives::Receipt;
 use reth_provider::{ReceiptProvider, ReceiptProviderIdExt};
 use std::fmt::Debug;
 use std::future::IntoFuture;
-use std::ops::RangeBounds;
+use std::ops::{RangeBounds, RangeInclusive};
 use tokio::runtime::Handle;
 
 impl<P, NP> ReceiptProvider for AlloyRethProvider<P, NP>
@@ -44,6 +44,10 @@ where
     }
 
     fn receipts_by_tx_range(&self, _range: impl RangeBounds<TxNumber>) -> ProviderResult<Vec<Receipt>> {
+        todo!()
+    }
+
+    fn receipts_by_block_range(&self, _block_range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Vec<Self::Receipt>>> {
         todo!()
     }
 }

--- a/src/provider/storage_api/state.rs
+++ b/src/provider/storage_api/state.rs
@@ -103,7 +103,11 @@ where
     }
 
     fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
-        Ok(Box::new(AlloyRethStateProvider::new_with_config(self.provider.clone(), block.into(), self.state_provider_config.clone())))
+        Ok(Box::new(AlloyRethStateProvider::new_with_config(
+            self.provider.clone(),
+            block.into(),
+            self.reth_provider_config.state_provider_config.clone(),
+        )))
     }
 
     fn state_by_block_hash(&self, hash: BlockHash) -> ProviderResult<StateProviderBox> {

--- a/src/provider/storage_api/state.rs
+++ b/src/provider/storage_api/state.rs
@@ -103,7 +103,7 @@ where
     }
 
     fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
-        Ok(Box::new(AlloyRethStateProvider::new(self.provider.clone(), block.into())))
+        Ok(Box::new(AlloyRethStateProvider::new_with_config(self.provider.clone(), block.into(), self.state_provider_config.clone())))
     }
 
     fn state_by_block_hash(&self, hash: BlockHash) -> ProviderResult<StateProviderBox> {

--- a/src/state_provider/alloy_reth_state_provider.rs
+++ b/src/state_provider/alloy_reth_state_provider.rs
@@ -9,17 +9,29 @@ use reth_primitives::Bytecode;
 use std::marker::PhantomData;
 use tokio::runtime::{Handle, Runtime};
 
+#[derive(Debug, Clone, Default)]
+pub struct AlloyRethStateProviderConfig {
+    /// Enable state root updates calculation
+    /// If disabled, the state root will default to zero
+    pub enable_state_root_updates: bool,
+}
+
 pub struct AlloyRethStateProvider<N: Network, P: Provider<N> + Clone> {
     rt: Option<Runtime>,
     pub(crate) provider: P,
     pub(crate) alloy_db: WrapDatabaseAsync<AlloyDBFork<N, P>>,
     pub(crate) bytecode: RwLock<HashMap<B256, Bytecode>>,
     pub(crate) block_id: BlockId,
+    pub(crate) config: AlloyRethStateProviderConfig,
     _n: PhantomData<N>,
 }
 
 impl<N: Network, P: Provider<N> + Clone> AlloyRethStateProvider<N, P> {
     pub fn new(provider: P, block_id: BlockId) -> Self {
+        Self::new_with_config(provider, block_id, AlloyRethStateProviderConfig::default())
+    }
+
+    pub fn new_with_config(provider: P, block_id: BlockId, config: AlloyRethStateProviderConfig) -> Self {
         let (handle, runtime) = match Handle::try_current() {
             // If we are already in a tokio runtime, use the current handle
             Ok(handle) => (handle, None),
@@ -32,7 +44,7 @@ impl<N: Network, P: Provider<N> + Clone> AlloyRethStateProvider<N, P> {
         };
         let alloy_db = AlloyDBFork::new(provider.clone(), block_id);
         let wrapped_db = WrapDatabaseAsync::with_handle(alloy_db, handle);
-        Self { rt: runtime, provider, alloy_db: wrapped_db, bytecode: RwLock::new(HashMap::default()), block_id, _n: PhantomData }
+        Self { rt: runtime, provider, alloy_db: wrapped_db, bytecode: RwLock::new(HashMap::default()), block_id, config, _n: PhantomData }
     }
 }
 

--- a/src/state_provider/alloy_reth_state_provider.rs
+++ b/src/state_provider/alloy_reth_state_provider.rs
@@ -11,8 +11,10 @@ use tokio::runtime::{Handle, Runtime};
 
 pub struct AlloyRethStateProvider<N: Network, P: Provider<N> + Clone> {
     rt: Option<Runtime>,
+    pub(crate) provider: P,
     pub(crate) alloy_db: WrapDatabaseAsync<AlloyDBFork<N, P>>,
     pub(crate) bytecode: RwLock<HashMap<B256, Bytecode>>,
+    pub(crate) block_id: BlockId,
     _n: PhantomData<N>,
 }
 
@@ -30,7 +32,7 @@ impl<N: Network, P: Provider<N> + Clone> AlloyRethStateProvider<N, P> {
         };
         let alloy_db = AlloyDBFork::new(provider.clone(), block_id);
         let wrapped_db = WrapDatabaseAsync::with_handle(alloy_db, handle);
-        Self { rt: runtime, alloy_db: wrapped_db, bytecode: RwLock::new(HashMap::default()), _n: PhantomData }
+        Self { rt: runtime, provider, alloy_db: wrapped_db, bytecode: RwLock::new(HashMap::default()), block_id, _n: PhantomData }
     }
 }
 

--- a/src/state_provider/storage_api/state.rs
+++ b/src/state_provider/storage_api/state.rs
@@ -13,7 +13,7 @@ use revm_database::BundleState;
 use revm_database::DatabaseRef;
 use std::future::IntoFuture;
 use tokio::runtime::Handle;
-use tracing::warn;
+use tracing::{info, warn};
 
 impl<N, P> StateProvider for AlloyRethStateProvider<N, P>
 where
@@ -60,7 +60,10 @@ where
             )
         });
         match result {
-            Ok(r) => Ok(r),
+            Ok(r) => {
+                info!(block=?self.block_id, state_root=?r.0, "Got result for state_root_with_updates");
+                Ok(r)
+            }
             Err(err) => Err(ProviderError::Other(AnyError::new(err))),
         }
     }

--- a/src/state_provider/storage_api/state.rs
+++ b/src/state_provider/storage_api/state.rs
@@ -1,4 +1,5 @@
 use crate::AlloyRethStateProvider;
+use alloy_eips::BlockId;
 use alloy_network::Network;
 use alloy_primitives::{Address, StorageKey, StorageValue, B256};
 use alloy_provider::Provider;
@@ -10,6 +11,8 @@ use reth_trie::updates::TrieUpdates;
 use reth_trie::{HashedPostState, KeccakKeyHasher, TrieInput};
 use revm_database::BundleState;
 use revm_database::DatabaseRef;
+use std::future::IntoFuture;
+use tokio::runtime::Handle;
 use tracing::warn;
 
 impl<N, P> StateProvider for AlloyRethStateProvider<N, P>
@@ -46,7 +49,20 @@ where
     }
 
     fn state_root_with_updates(&self, hashed_state: HashedPostState) -> ProviderResult<(B256, TrieUpdates)> {
-        self.state_root_from_nodes_with_updates(TrieInput::from_state(hashed_state))
+        let result = tokio::task::block_in_place(move || {
+            Handle::current().block_on(
+                self.provider
+                    .raw_request::<(HashedPostState, BlockId), (B256, TrieUpdates)>(
+                        "debug_stateRootWithUpdates".into(),
+                        (hashed_state, self.block_id),
+                    )
+                    .into_future(),
+            )
+        });
+        match result {
+            Ok(r) => Ok(r),
+            Err(err) => Err(ProviderError::Other(AnyError::new(err))),
+        }
     }
 
     fn state_root_from_nodes_with_updates(&self, _input: TrieInput) -> ProviderResult<(B256, TrieUpdates)> {

--- a/src/state_provider/storage_api/state.rs
+++ b/src/state_provider/storage_api/state.rs
@@ -49,6 +49,10 @@ where
     }
 
     fn state_root_with_updates(&self, hashed_state: HashedPostState) -> ProviderResult<(B256, TrieUpdates)> {
+        if !self.config.enable_state_root_updates {
+            return Ok((B256::ZERO, TrieUpdates::default()));
+        }
+
         let result = tokio::task::block_in_place(move || {
             Handle::current().block_on(
                 self.provider


### PR DESCRIPTION
This will add:
- Example for state `state_root_with_updates` call
- Using the `debug_stateRootWithUpdates` method from reth

This is currently waiting for: https://github.com/paradigmxyz/reth/pull/16353

The PR is currently using the custom reth branch to make it work. When the method is available in reth I will update this branch.